### PR TITLE
Update FileDescription.cs

### DIFF
--- a/src/DataAccess/Model/FileDescription.cs
+++ b/src/DataAccess/Model/FileDescription.cs
@@ -10,5 +10,6 @@ namespace DataAccess.Model
         public DateTime CreatedTimestamp { get; set; }
         public DateTime UpdatedTimestamp { get; set; }
         public string ContentType { get; set; }
+        public string Path_locator { get; set; }
     }
 }


### PR DESCRIPTION
Added path_locator property to set the Primary key of the File Table instead of the file name.
GetPathLocator(string filestreampath ) SQL Server function will return the path locator. I don't know how can you use it in EF but I am using it with SqlCommand directly.

filestreampath: "\\{yourPCname}\{mssqlserver}\WebApiFileTable\WebApiUploads_Dir\\filename"